### PR TITLE
Hacking around problem with using | in a md table

### DIFF
--- a/functions/operators.md
+++ b/functions/operators.md
@@ -11,8 +11,8 @@
 | `!`      | Factorial              | `XY!`          | `5!`                | 120    |
 | `&`      | Bitwise And            | `AB & XY`      | `5 & 3`             | 1      |
 | `~`      | Bitwise Not            | `~AB`          | `~2`                | -3     |
-| `\|`     | Bitwise Or             | `AB \| XY`     | `5 \| 3`            | 7      |
-| `^\|`    | Bitwise Xor            | `AB ^\| XY`    | `5 ^\| 2`           | 6      |
+| `⎮`      | Bitwise Or             | `AB ⎮ XY`      | `5 ⎮ 3`             | 7      |
+| `^⎮`     | Bitwise Xor            | `AB ^⎮ XY`     | `5 ^⎮ 2`            | 6      |
 | `? :`    | Conditional Expression | `AB ? XY : PQ` | `15 > 100 ? 1 : -1` | -1     |
 
 Table from the [math.js documentation](http://mathjs.org/docs/expressions/syntax.html), filtered to the subset


### PR DESCRIPTION
I've swapped the offending pipe that didn't escape properly for a unicode vertical line character. This may cause issues if people try to copy paste directly into metric cells, but at least it renders properly.
